### PR TITLE
added uninstall guard for shutting down telemetry tracer provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ use tracing::{info, info_span};
 fn main() -> std::io::Result<()> {
     let subscriber = configure_subscriber(builder("simple").with_env("dev".to_string()).build());
 
-    init_subscriber(subscriber);
+    let _guard = init_subscriber(subscriber);
 
     let span = info_span!("MySpan");
     let _guard = span.enter();
@@ -52,7 +52,7 @@ use tracing::{info, info_span};
 fn main() -> std::io::Result<()> {
     let subscriber = configure_subscriber(builder("json").with_env("dev".to_string()).build());
 
-    init_subscriber(subscriber);
+    let _guard = init_subscriber(subscriber);
 
     let span = info_span!("MySpan");
     let _guard = span.enter();
@@ -80,7 +80,7 @@ fn main() -> std::io::Result<()> {
             .build(),
     );
 
-    init_subscriber(subscriber);
+    let _guard = init_subscriber(subscriber);
 
     let span = info_span!("MySpan");
     let _guard = span.enter();

--- a/examples/custom_formatter.rs
+++ b/examples/custom_formatter.rs
@@ -15,7 +15,7 @@ async fn main() -> std::io::Result<()> {
             .build(),
     );
 
-    init_subscriber(subscriber);
+    let _guard = init_subscriber(subscriber);
     HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -23,7 +23,7 @@ async fn main() -> std::io::Result<()> {
             .build(),
     );
 
-    init_subscriber(subscriber);
+    let _guard = init_subscriber(subscriber);
 
     let bridge = Arc::new(Bridge::new("http://localhost:8082".parse().unwrap()));
     HttpServer::new(move || {

--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -15,7 +15,7 @@ async fn main() -> std::io::Result<()> {
             .build(),
     );
 
-    init_subscriber(subscriber);
+    let _guard = init_subscriber(subscriber);
     HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -4,7 +4,7 @@ use tracing::{info, info_span};
 fn main() -> std::io::Result<()> {
     let subscriber = configure_subscriber(builder("simple").with_env("dev".to_string()).build());
 
-    init_subscriber(subscriber);
+    let _trace_guard = init_subscriber(subscriber);
 
     let span = info_span!("MySpan");
     let _guard = span.enter();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!        .build()
 //!    );
 //!
-//!    init_subscriber(subscriber);
+//!    let _guard = init_subscriber(subscriber);
 //! }
 //! ```
 


### PR DESCRIPTION
This PR adds the uninstall guard for shutting down automatically the trace provider when the feature `prima-telemetry` is enabled