### PR TITLE
Fix signals handling to allow graceful applications' shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ required-features = ["prima-logger-json"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-opentelemetry = { version = "0.16", features = ["rt-tokio"], optional = true }
+opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"], optional = true }
 opentelemetry-zipkin = { version = "0.14", features = ["reqwest-client"], default-features = false, optional = true }
 tracing = { version = "0.1", features = ["max_level_debug", "release_max_level_info"] }
 tracing-opentelemetry = { version = "0.16", optional = true }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -26,7 +26,7 @@ pub fn configure<T>(config: &SubscriberConfig<T>) -> Tracer {
                 config.env.clone(),
             )])),
         )
-        .install_batch(opentelemetry::runtime::Tokio)
+        .install_batch(opentelemetry::runtime::TokioCurrentThread)
         .expect("Failed to create the zipkin pipeline")
 }
 


### PR DESCRIPTION
When using this library within an `actix 4` application, we face the following issue: https://github.com/actix/actix-web/issues/2638

Basically if the application has the `actix_web::main` macro in the entrypoint, it's not able to handle signals to shutdown gracefully. The hack to solve this is to replace the former macro with `tokio::main`.

However this issue has been resolved in the `opentelemetry` repo, where the maintainers suggested to replace `opentelemetry::runtime::Tokio` with `opentelemetry::runtime::TokioCurrentThread` when initializing the tracer. I've done a couple tests locally and it seems to work exactly the same, either when tracing is initialized within an actix web context, as well as when it's initialized inside a pure tokio context.

I please ask you to review the change carefully because I don't have any deep knowledge with tokio, nor opentelemetry stuff (or rust at all :D)