### PR TITLE
environment as a root field in json logging

### DIFF
--- a/src/json/formatter.rs
+++ b/src/json/formatter.rs
@@ -116,6 +116,7 @@ impl EventFormatter for DefaultEventFormatter {
             "level",
             metadata.level().to_string().to_lowercase().as_str(),
         )?;
+        map_serializer.serialize_entry("environment", info.environment())?;
         map_serializer.serialize_entry("type", info.app_name())?;
 
         let mut visitor = PrimaJsonVisitor::default();


### PR DESCRIPTION
@larrywax said that we should log the environment as a root field in the json formatter, not inside the metadata.