### PR TITLE
Improve changelog for 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 OpenTelemetry traces are now exported using the **OTLP** format instead of the Zipkin one.  
-If you are using Jaeger to collect traces locally on your machine, you need to change the Docker image to `jaegertracing/opentelemetry-all-in-one:latest` and set the OpenTelemetry endpoint to `http://[HOST]:55681/v1/traces`. 
+⚠️ You will need to change the OpenTelemetry collector endpoint to `http://[HOSTNAME]:55681/v1/traces`.   
+If you are using Jaeger to collect traces locally on your machine, you will also need to change the Docker image to `jaegertracing/opentelemetry-all-in-one:latest`.
 
 [Next]: https://github.com/primait/prima_tracing.rs/compare/0.4.0...HEAD
 [0.4.0]: https://github.com/primait/prima_tracing.rs/compare/0.3.1...0.4.0


### PR DESCRIPTION
The otel collector endpoint will need to be changed everywhere, not only in local configuration.