### PR TITLE
Improve instructions for using Jaeger locally in Docker Compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Next]
 
 ### Changed
-Update dependencies
+Update dependencies  
 ⚠️  Increase the minimum rust version to 1.57.0
 
 ## [0.4.0] - 2022-06-09
 
 ### Changed
 OpenTelemetry traces are now exported using the **OTLP** format instead of the Zipkin one.  
-⚠️  You will need to change the OpenTelemetry collector endpoint to `http://[HOSTNAME]:55681/v1/traces`.   
-If you are using Jaeger to collect traces locally on your machine, you will also need to change the Docker image to `jaegertracing/opentelemetry-all-in-one:latest`.
+⚠️  You will need to change the OpenTelemetry collector endpoint to `http://[HOSTNAME]:55681/v1/traces`. 
+
+If you are using Jaeger to collect traces locally on your machine, you will need to update your Docker Compose setup to the following:
+```yaml
+  jaeger:
+    image: jaegertracing/all-in-one:1.35
+    ports:
+      - 16686:16686
+      - 55681:55681
+    environment:
+      COLLECTOR_OTLP_ENABLED: true
+      COLLECTOR_OTLP_HTTP_HOST_PORT: 55681
+```
 
 [Next]: https://github.com/primait/prima_tracing.rs/compare/0.4.0...HEAD
 [0.4.0]: https://github.com/primait/prima_tracing.rs/compare/0.3.1...0.4.0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install from [crates.io](https://crates.io/crates/prima-tracing)
 prima-tracing = "0.4.0"
 ```
 
-## Cargo features
+### Cargo features
 
 - `prima-logger-json` outputs traces to standard output in JSON format
 - `prima-logger-datadog` extends `prima-logger-json` output
@@ -24,6 +24,23 @@ prima-tracing = "0.4.0"
 - `prima-telemetry` exports OpenTelemetry traces using the [opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp) exporter
 - `rt-tokio-current-thread` configures the OpenTelemetry tracer to use Tokio’s current thread runtime
   (e.g. `actix_web::main`). Without this feature, the Tokio multi-thread runtime is used by default.
+
+## How to collect OpenTelemetry traces locally
+
+If you are using the `prima-telemetry` feature in your project, the recommended way to view exported traces on your machine is to use the [Jaeger all-in-one Docker image](https://hub.docker.com/r/jaegertracing/opentelemetry-all-in-one/).
+
+You need to add the following service to your Docker Compose setup (your main container should depend on it):
+```yaml
+  jaeger:
+    image: jaegertracing/all-in-one:1.35
+    ports:
+      - 16686:16686
+      - 55681:55681
+    environment:
+      COLLECTOR_OTLP_ENABLED: true
+      COLLECTOR_OTLP_HTTP_HOST_PORT: 55681
+```
+You can then visit the [Jaeger web UI](http://localhost:16686/search) on your browser to search the traces.
 
 ## Usage examples
 
@@ -137,7 +154,7 @@ RUST_LOG=info cargo run --example simple
 Run [Jaeger](https://www.jaegertracing.io) locally
 
 ```sh
-docker run --rm -d -p 16686:16686 -p 55681:55681 jaegertracing/opentelemetry-all-in-one:latest
+docker run --rm -d -p 16686:16686 -p 55681:55681 -e COLLECTOR_OTLP_ENABLED=true -e COLLECTOR_OTLP_HTTP_HOST_PORT=55681 jaegertracing/all-in-one:1.35
 ```
 
 Run pong service:


### PR DESCRIPTION
The changelog was updated to recommend using the latest version of `jaegertracing/all-in-one` image which supports the OTLP collector.
I've also added those instructions to the Readme, since they're quite useful and prima_opentelemetry_ex Readme has them too.