### PR TITLE
Update open telemetry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ required-features = ["json-logger"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-opentelemetry = { version = "0.18", features = ["rt-tokio"], optional = true }
-opentelemetry-otlp = { version = "0.11", features = ["http-proto", "reqwest-client"], default-features = false, optional = true }
+opentelemetry = { version = "0.19", features = ["rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.12", features = ["http-proto", "reqwest-client"], default-features = false, optional = true }
 tracing = { version = "0.1", features = ["max_level_debug", "release_max_level_info"] }
-tracing-opentelemetry = { version = "0.18", optional = true }
+tracing-opentelemetry = { version = "0.19", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-log = { version = "0.1" }
 
@@ -54,6 +54,6 @@ chrono = { version = "^0.4", default-features = false, features = ["serde", "clo
 
 [dev-dependencies]
 actix-web = "4.0.1"
-tracing-actix-web = { version = "0.7.0", features = ["opentelemetry_0_18"] }
+tracing-actix-web = { version = "0.7.0", features = ["opentelemetry_0_19"] }
 prima_bridge = "0.13"
 tokio = { version = "1.17", features = ["rt", "macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prima-tracing"
-version = "0.5.0"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 authors = ["Enrico Risa <enrico.risa@prima.it>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ required-features = ["json-logger"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-opentelemetry = { version = "0.17", features = ["rt-tokio"], optional = true }
-opentelemetry-otlp = { version = "0.10", features = ["http-proto", "reqwest-client"], default-features = false, optional = true }
+opentelemetry = { version = "0.18", features = ["rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.11", features = ["http-proto", "reqwest-client"], default-features = false, optional = true }
 tracing = { version = "0.1", features = ["max_level_debug", "release_max_level_info"] }
-tracing-opentelemetry = { version = "0.17", optional = true }
+tracing-opentelemetry = { version = "0.18", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-log = { version = "0.1" }
 
@@ -54,6 +54,6 @@ chrono = { version = "^0.4", default-features = false, features = ["serde", "clo
 
 [dev-dependencies]
 actix-web = "4.0.1"
-tracing-actix-web = { version = "0.7.0", features = ["opentelemetry_0_17"] }
+tracing-actix-web = { version = "0.7.0", features = ["opentelemetry_0_18"] }
 prima_bridge = "0.13"
 tokio = { version = "1.17", features = ["rt", "macros", "rt-multi-thread"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/prima/rust:1.59.0-2
+FROM public.ecr.aws/prima/rust:1.65.0-1
 
 # Serve per avere l'owner dei file scritti dal container uguale all'utente Linux sull'host
 USER app

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -64,15 +64,14 @@ where
 
         if let (Some(otel_data), Some(version)) = (extensions.get_mut::<OtelData>(), &self.version)
         {
-            let builder = &mut otel_data.builder;
-            let root_version = KeyValue::new("version", version.clone());
-            let service_version = KeyValue::new("service.version", version.clone());
-            if let Some(ref mut attributes) = builder.attributes {
-                attributes.push(root_version);
-                attributes.push(service_version);
-            } else {
-                builder.attributes = Some(vec![root_version, service_version]);
-            }
+            otel_data
+                .builder
+                .attributes
+                .get_or_insert_with(Default::default)
+                .extend([
+                    KeyValue::new("version", version.clone()),
+                    KeyValue::new("service.version", version.clone()),
+                ]);
         }
     }
 }


### PR DESCRIPTION
Currently this is blocked because a change in Open telemetry requires the protoc compile to be included in the build.

We could add this to the base container. However, it looks like they have backed out this change but it will not land until version `0.19.0` is released

https://github.com/open-telemetry/opentelemetry-rust/pull/881
https://github.com/open-telemetry/opentelemetry-rust/issues/873