### PR TITLE
[PLATFORM-1117]: Unify country once and for all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+### Added
+
+- Add `Common` to `Country`, since some services are common to all countries
+
 ## [0.6.2] - 2023-05-30
 
 ### Changed
 
-- trace resources are all set correctly
+- Trace resources are all set correctly
 
 ## [0.6.1] - 2023-05-30
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For ease of use you can use the following feature sets:
 If you are using the `tracing` feature in your project, the recommended way to view exported traces on your machine is to use the [Jaeger all-in-one Docker image](https://hub.docker.com/r/jaegertracing/opentelemetry-all-in-one/).
 
 You need to add the following service to your Docker Compose setup (your main container should depend on it):
+
 ```yaml
   jaeger:
     image: jaegertracing/all-in-one:1.35
@@ -45,6 +46,7 @@ You need to add the following service to your Docker Compose setup (your main co
       COLLECTOR_OTLP_ENABLED: true
       COLLECTOR_OTLP_HTTP_HOST_PORT: 55681
 ```
+
 You can then visit the [Jaeger web UI](http://localhost:16686/search) on your browser to search the traces.
 
 ## Usage examples
@@ -56,7 +58,12 @@ use prima_tracing::{builder, configure_subscriber, init_subscriber, Environment}
 use tracing::{info, info_span};
 
 fn main() -> std::io::Result<()> {
-    let subscriber = configure_subscriber(builder("simple").with_env(Environment::Dev).build());
+    let subscriber = configure_subscriber(
+      builder("simple")
+        .with_country(Country::Common)
+        .with_env(Environment::Dev)
+        .build()
+    );
 
     let _guard = init_subscriber(subscriber);
 
@@ -77,7 +84,12 @@ use prima_tracing::{builder, configure_subscriber, init_subscriber, Environment}
 use tracing::{info, info_span};
 
 fn main() -> std::io::Result<()> {
-    let subscriber = configure_subscriber(builder("json").with_env(Environment::Dev).build());
+    let subscriber = configure_subscriber(
+      builder("json")
+        .with_country(Country::Common)
+        .with_env(Environment::Dev)
+        .build()
+    );
 
     let _guard = init_subscriber(subscriber);
 
@@ -101,6 +113,7 @@ use tracing::{info, info_span};
 fn main() -> std::io::Result<()> {
     let subscriber = configure_subscriber(
         builder("myapp")
+            .with_country(Country::Common)
             .with_env(Environment::Dev)
             .with_version("1.0".to_string())
             .with_telemetry(

--- a/examples/custom_formatter.rs
+++ b/examples/custom_formatter.rs
@@ -14,7 +14,7 @@ async fn main() -> std::io::Result<()> {
         builder("custom")
             .with_env(Environment::Dev)
             .with_custom_json_formatter(MyCustomFormatter {})
-            .with_country(Country::Es)
+            .with_country(Country::Common)
             .build(),
     );
 

--- a/examples/datadog_json_logger.rs
+++ b/examples/datadog_json_logger.rs
@@ -7,7 +7,7 @@ async fn main() {
     let subscriber = configure_subscriber(
         builder(&service_name)
             .with_env(Environment::Dev)
-            .with_country(Country::Es)
+            .with_country(Country::Common)
             .with_version("1.0".to_string())
             // We need a tracer if we want trace and span IDs to be created and propagated, otherwise logs won't contain these correlation IDs
             // You can also setup custom tracer and custom subscriber if you don't wanna use the `traces` feature

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -13,7 +13,7 @@ async fn main() -> std::io::Result<()> {
     let subscriber = configure_subscriber(
         builder("ping")
             .with_env(Environment::Dev)
-            .with_country(Country::Es)
+            .with_country(Country::Common)
             .with_version("1.0".to_string())
             .with_telemetry(
                 "http://localhost:55681/v1/traces".to_string(),

--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -8,7 +8,7 @@ async fn main() -> std::io::Result<()> {
     let subscriber = configure_subscriber(
         builder("pong")
             .with_env(Environment::Dev)
-            .with_country(Country::Es)
+            .with_country(Country::Common)
             .with_version("1.0".to_string())
             .with_telemetry(
                 "http://localhost:55681/v1/traces".to_string(),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -5,7 +5,7 @@ fn main() -> std::io::Result<()> {
     let subscriber = configure_subscriber(
         builder("simple")
             .with_env(Environment::Dev)
-            .with_country(Country::Es)
+            .with_country(Country::Common)
             .build(),
     );
 

--- a/src/config/country.rs
+++ b/src/config/country.rs
@@ -6,8 +6,9 @@ use std::{
 /// All the possible countries in which the application can run.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Country {
-    It,
+    Common,
     Es,
+    It,
     Uk,
 }
 
@@ -16,6 +17,7 @@ impl FromStr for Country {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "common" => Ok(Self::Common),
             "it" => Ok(Self::It),
             "es" => Ok(Self::Es),
             "uk" => Ok(Self::Uk),
@@ -27,11 +29,12 @@ impl FromStr for Country {
 impl Display for Country {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let country = match self {
+            Self::Common => "common",
             Self::Es => "es",
             Self::It => "it",
             Self::Uk => "uk",
         };
-        f.write_str(format!("prima:country:{}", country).as_str())
+        f.write_str(country)
     }
 }
 
@@ -41,7 +44,7 @@ pub struct CountryParseError(String);
 impl Display for CountryParseError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!(
-            "{} is not a valid country string. Allowed strings are 'it', 'es' and 'uk'.",
+            "{} is not a valid country string. Allowed strings are 'common', 'it', 'es' and 'uk'.",
             &self.0
         ))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! let subscriber = configure_subscriber(
 //!   builder("ping")
-//!     .with_country(Country::Es)
+//!     .with_country(Country::Common)
 //!     .with_env(Environment::Dev)
 //!     .build()
 //! );


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-1117

~~Let's take Fiume!~~

This PR

- unifies the `country` param with `prima_datadog.rs`: we should include `Common` because logs and traces may come from services that are common to all countries (thanks @maeisbad)
- country is now formatted to just `code` because it doesn't make sense for the string to be `prima:country:code`: the tag already is `country`, the content can simply be the code

