### PR TITLE
[PLATFORM-1256]: Try aligning dependabot bumps for otel libraries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
   groups:
     # Dependencies that need to be kept in sync
     otel:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,14 @@
 
 version: 2
 updates:
-  - package-ecosystem: cargo # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  groups:
+    # Dependencies that need to be kept in sync
+    otel:
+      patterns: 
+        - "opentelemetry*"
+        - "tracing-opentelemetry"


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-1256

Not really sure about the `opentelemetry*`, which should include `opentelemetry-otlp`

