### PR TITLE
[PLATFORM-1399]: Update otel deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `opentelemetry_sdk` dependency, which inherits the `rt-tokio` feature
+
+### Changed
+
+- Bump `opentelemetry` to 0.21 and remove the `rt-tokio` feature
+- Bump `opentelemetry-otlp` to 0.14
+- Bump `tracing-opentelemetry` to 0.22
+- Move `rt-tokio-current-thread` to map to `["opentelemetry_sdk/rt-tokio-current-thread"]`, the tokio stuff has been moved to `opentelemetry_sdk`
+
 ---
 
 ## [0.7.2] - 2023-10-26
+
+### Changed
 
 - Bump `tracing-log` to 0.2
 
@@ -101,7 +114,6 @@ If you are using Jaeger to collect traces locally on your machine, you will need
       COLLECTOR_OTLP_ENABLED: true
       COLLECTOR_OTLP_HTTP_HOST_PORT: 55681
 ```
-
 
 [Unreleased]: https://github.com/primait/prima_tracing.rs/compare/0.7.2...HEAD
 [0.7.2]: https://github.com/primait/prima_tracing.rs/compare/0.7.1...0.7.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,4 @@ chrono = {version = "^0.4", default-features = false, features = ["serde", "cloc
 actix-web = "4.0.1"
 prima_bridge = "0.15"
 tokio = {version = "1.17", features = ["rt", "macros", "rt-multi-thread"]}
-tracing-actix-web = {version = "0.7.0", features = ["opentelemetry_0_20"]}
+tracing-actix-web = {version = "0.7.0", features = ["opentelemetry_0_21"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ traces = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-otlp"]
 dev = ["traces"]
 live = ["json-logger", "datadog", "traces"]
 
-rt-tokio-current-thread = ["opentelemetry/rt-tokio-current-thread"]
+rt-tokio-current-thread = ["opentelemetry_sdk/rt-tokio-current-thread"]
 
 [[example]]
 name = "custom-json-subscriber"
@@ -37,8 +37,9 @@ required-features = ["json-logger"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-opentelemetry = {version = "0.21", features = ["rt-tokio"], optional = true}
+opentelemetry = {version = "0.21", optional = true}
 opentelemetry-otlp = {version = "0.14", features = ["http-proto", "reqwest-client"], default-features = false, optional = true}
+opentelemetry_sdk = {version = "0.21", features = ["rt-tokio"], optional = true}
 tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_info"]}
 tracing-log = {version = "0.2"}
 tracing-opentelemetry = {version = "0.22", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ required-features = ["json-logger"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-opentelemetry = {version = "0.20", features = ["rt-tokio"], optional = true}
-opentelemetry-otlp = {version = "0.13", features = ["http-proto", "reqwest-client"], default-features = false, optional = true}
+opentelemetry = {version = "0.21", features = ["rt-tokio"], optional = true}
+opentelemetry-otlp = {version = "0.14", features = ["http-proto", "reqwest-client"], default-features = false, optional = true}
 tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_info"]}
 tracing-log = {version = "0.2"}
-tracing-opentelemetry = {version = "0.21", optional = true}
+tracing-opentelemetry = {version = "0.22", optional = true}
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 
 # serialization/deserialization

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -58,7 +58,8 @@ pub fn init_subscriber(subscriber: impl Subscriber + Sync + Send) -> Uninstall {
 
     #[cfg(feature = "traces")]
     {
-        use opentelemetry::{global, sdk::propagation::TraceContextPropagator};
+        use opentelemetry::global;
+        use opentelemetry_sdk::propagation::TraceContextPropagator;
         global::set_text_map_propagator(TraceContextPropagator::new());
     };
     Uninstall

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,11 +1,9 @@
-use opentelemetry::{
-    sdk::{
-        trace::{self, Tracer},
-        Resource,
-    },
-    KeyValue,
-};
+use opentelemetry::KeyValue;
 use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{
+    trace::{self, Tracer},
+    Resource,
+};
 use tracing::{span, Subscriber};
 use tracing_opentelemetry::OtelData;
 use tracing_subscriber::{layer::Context, Layer};
@@ -21,11 +19,11 @@ pub fn configure<T>(config: &SubscriberConfig<T>) -> Tracer {
     let runtime = {
         #[cfg(feature = "rt-tokio-current-thread")]
         {
-            opentelemetry::runtime::TokioCurrentThread
+            opentelemetry_sdk::runtime::TokioCurrentThread
         }
         #[cfg(not(feature = "rt-tokio-current-thread"))]
         {
-            opentelemetry::runtime::Tokio
+            opentelemetry_sdk::runtime::Tokio
         }
     };
 


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-1399

In this PR

- `opentelemetry` has been bumped to `0.21` and the `rt-tokio` feature has been removed
- `opentelemetry-otlp` has been bumped to `0.14`
- `opentelemetry_sdk` has been introduced, with the `rt-tokio` feature
- `tracing-opentelemetry` is now `0.22` to match the other otel deps
- updates the flag `rt-tokio-current-thread` to map to `["opentelemetry_sdk/rt-tokio-current-thread"]`, since the tokio stuff has been moved to `opentelemetry_sdk`
