### PR TITLE
[PLATFORM-1583]: Look into automatically attaching error tracking metadata 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.1] - 2024-04-08
+
+### Added
+
+- Added an `ErrorLayer` to add `error.message`, `error.type` and `error.stack` to the log metadata when a `tracing::Event` 
+  is an `Error`.
+
+---
+
 ## [0.9.0] - 2024-03-26
 
 No new changes since 0.9.0-rc.1
@@ -163,7 +172,8 @@ If you are using Jaeger to collect traces locally on your machine, you will need
 
 
 
-[Unreleased]: https://github.com/primait/prima_tracing.rs/compare/0.9.0...HEAD
+[Unreleased]: https://github.com/primait/prima_tracing.rs/compare/0.9.1...HEAD
+[0.9.1]: https://github.com/primait/prima_tracing.rs/compare/0.9.0...0.9.1
 [0.9.0]: https://github.com/primait/prima_tracing.rs/compare/0.9.0-rc.1...0.9.0
 [0.9.0-rc.1]: https://github.com/primait/prima_tracing.rs/compare/0.9.0-rc.0...0.9.0-rc.1
 [0.9.0-rc.0]: https://github.com/primait/prima_tracing.rs/compare/0.8.1...0.9.0-rc.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ opentelemetry = {version = "0.21", optional = true}
 opentelemetry-otlp = {version = "0.14", features = ["http-proto", "reqwest-client"], default-features = false, optional = true}
 opentelemetry_sdk = {version = "0.21", features = ["rt-tokio"], optional = true}
 tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_info"]}
+tracing-core = "0.1"
 tracing-log = {version = "0.2"}
 tracing-opentelemetry = {version = "0.22", optional = true}
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ opentelemetry = {version = "0.21", optional = true}
 opentelemetry-otlp = {version = "0.14", features = ["http-proto", "reqwest-client"], default-features = false, optional = true}
 opentelemetry_sdk = {version = "0.21", features = ["rt-tokio"], optional = true}
 tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_info"]}
-tracing-core = "0.1"
 tracing-log = {version = "0.2"}
 tracing-opentelemetry = {version = "0.22", optional = true}
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "prima-tracing"
 readme = "README.md"
 repository = "https://github.com/primait/prima_tracing.rs"
-version = "0.9.0"
+version = "0.9.1"
 
 [features]
 default = []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/prima/rust:1.72.0
+FROM public.ecr.aws/prima/rust:1.76.0
 
 # Serve per avere l'owner dei file scritti dal container uguale all'utente Linux sull'host
 USER app

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Install from [crates.io](https://crates.io/crates/prima-tracing)
 
 ```toml
-prima-tracing = "0.8"
+prima-tracing = "0.9"
 ```
 
 ### Cargo features

--- a/src/layer/error.rs
+++ b/src/layer/error.rs
@@ -1,0 +1,60 @@
+use opentelemetry::KeyValue;
+use tracing::field::Field;
+use tracing::field::Visit;
+use tracing::Event;
+use tracing::Level;
+use tracing::Subscriber;
+use tracing_opentelemetry::OtelData;
+use tracing_subscriber::{registry::LookupSpan, Layer};
+
+pub struct ErrorLayer;
+
+impl<S> Layer<S> for ErrorLayer
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn on_event(&self, event: &Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        if event.metadata().is_event() && event.metadata().level() == &Level::ERROR {
+            let mut visitor = ErrorVisitor::default();
+            event.record(&mut visitor);
+
+            if let Some(span) = ctx.lookup_current() {
+                if let Some(data) = span.extensions_mut().get_mut::<OtelData>() {
+                    let builder_attrs =
+                        data.builder.attributes.get_or_insert(Vec::with_capacity(3));
+                    builder_attrs.extend([
+                        KeyValue::new("error.message", visitor.message),
+                        KeyValue::new("error.type", visitor.kind),
+                        KeyValue::new("error.stack", visitor.stack),
+                    ]);
+                }
+            };
+        }
+    }
+}
+
+#[derive(Default)]
+struct ErrorVisitor {
+    message: String,
+    kind: String,
+    stack: String,
+}
+
+impl Visit for ErrorVisitor {
+    fn record_error(&mut self, _field: &Field, value: &(dyn std::error::Error + 'static)) {
+        let mut source: String = format!("Stack:\n{}", value);
+        let mut next_err = value.source();
+
+        while let Some(err) = next_err {
+            source.push_str(&format!("\n{}", err));
+            next_err = err.source();
+        }
+
+        let error_msg = value.to_string();
+
+        self.message = error_msg;
+        self.kind = "Error".to_string();
+        self.stack = source;
+    }
+    fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
+}

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -1,0 +1,5 @@
+pub use error::ErrorLayer;
+pub use version::VersionLayer;
+
+mod error;
+mod version;

--- a/src/layer/version.rs
+++ b/src/layer/version.rs
@@ -2,8 +2,8 @@ use opentelemetry::KeyValue;
 use tracing::span;
 use tracing::Subscriber;
 use tracing_opentelemetry::OtelData;
-use tracing_subscriber::Layer;
 use tracing_subscriber::layer::Context;
+use tracing_subscriber::Layer;
 
 pub struct VersionLayer {
     pub version: Option<String>,

--- a/src/layer/version.rs
+++ b/src/layer/version.rs
@@ -1,0 +1,32 @@
+use opentelemetry::KeyValue;
+use tracing::span;
+use tracing_core::Subscriber;
+use tracing_opentelemetry::OtelData;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::Layer;
+
+pub struct VersionLayer {
+    pub version: Option<String>,
+}
+
+impl<S> Layer<S> for VersionLayer
+where
+    S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fn on_new_span(&self, _attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        if let (Some(otel_data), Some(version)) = (extensions.get_mut::<OtelData>(), &self.version)
+        {
+            otel_data
+                .builder
+                .attributes
+                .get_or_insert_with(Default::default)
+                .extend([
+                    KeyValue::new("version", version.clone()),
+                    KeyValue::new("service.version", version.clone()),
+                ]);
+        }
+    }
+}

--- a/src/layer/version.rs
+++ b/src/layer/version.rs
@@ -1,9 +1,9 @@
 use opentelemetry::KeyValue;
 use tracing::span;
-use tracing_core::Subscriber;
+use tracing::Subscriber;
 use tracing_opentelemetry::OtelData;
-use tracing_subscriber::layer::Context;
 use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
 
 pub struct VersionLayer {
     pub version: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ mod subscriber;
 #[cfg(feature = "json-logger")]
 pub mod json;
 #[cfg(feature = "traces")]
+pub mod layer;
+#[cfg(feature = "traces")]
 pub mod telemetry;
 
 pub use crate::config::{

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -27,9 +27,10 @@ pub fn configure_subscriber<T: EventFormatter + Send + Sync + 'static>(
         let tracer = crate::telemetry::configure(&_config);
         subscriber
             .with(tracing_opentelemetry::layer().with_tracer(tracer))
-            .with(crate::telemetry::VersionLayer {
+            .with(crate::layer::VersionLayer {
                 version: _config.version.clone(),
             })
+            .with(crate::layer::ErrorLayer)
     };
 
     #[cfg(not(feature = "json-logger"))]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -4,9 +4,6 @@ use opentelemetry_sdk::{
     trace::{self, Tracer},
     Resource,
 };
-use tracing::{span, Subscriber};
-use tracing_opentelemetry::OtelData;
-use tracing_subscriber::{layer::Context, Layer};
 
 use crate::SubscriberConfig;
 
@@ -56,30 +53,4 @@ pub fn configure<T>(config: &SubscriberConfig<T>) -> Tracer {
         .with_trace_config(trace::config().with_resource(resource))
         .install_batch(runtime)
         .expect("Failed to configure the OpenTelemetry tracer")
-}
-
-pub struct VersionLayer {
-    pub version: Option<String>,
-}
-
-impl<S> Layer<S> for VersionLayer
-where
-    S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
-{
-    fn on_new_span(&self, _attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
-        let span = ctx.span(id).expect("Span not found, this is a bug");
-        let mut extensions = span.extensions_mut();
-
-        if let (Some(otel_data), Some(version)) = (extensions.get_mut::<OtelData>(), &self.version)
-        {
-            otel_data
-                .builder
-                .attributes
-                .get_or_insert_with(Default::default)
-                .extend([
-                    KeyValue::new("version", version.clone()),
-                    KeyValue::new("service.version", version.clone()),
-                ]);
-        }
-    }
 }

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,5 +1,8 @@
+use std::fmt::{Debug, Display, Formatter};
+
 use opentelemetry_jaeger::testing::jaeger_api_v2::Span;
 use opentelemetry_jaeger::testing::jaeger_client::JaegerTestClient;
+
 use prima_tracing::{builder, configure_subscriber, init_subscriber, Country, Environment};
 
 async fn get_spans(f: impl FnOnce(), collector_url: &str) -> Option<Vec<Span>> {
@@ -114,4 +117,69 @@ async fn strips_trailing_endpoint() {
     )
     .await
     .expect("Failed to fetch traces from jaeger");
+}
+
+#[cfg(feature = "traces")]
+#[tokio::test(flavor = "multi_thread")]
+async fn error_layer_enrich_errored_spans() {
+    std::env::set_var("RUST_LOG", "info");
+
+    // Unique id for this test run
+    let seed = std::fs::read_to_string("/proc/sys/kernel/random/uuid").unwrap();
+    let service_name = format!("e2e-test-{seed}");
+
+    let query_api_url = "http://jaeger:16685/";
+
+    let subscriber = configure_subscriber(
+        builder(&service_name)
+            .with_country(Country::Common)
+            .with_env(Environment::Dev)
+            .with_telemetry("http://jaeger:55681".to_string(), service_name.clone())
+            .build(),
+    );
+
+    {
+        let _guard = init_subscriber(subscriber);
+        let error = Error {
+            message: "error message".to_string(),
+        };
+        let span = tracing::error_span!("An error occurred");
+        span.in_scope(|| {
+            tracing::error!(
+                error = &error as &dyn std::error::Error,
+                "An error occurred"
+            );
+        });
+    };
+
+    let mut client = JaegerTestClient::new(query_api_url);
+
+    let spans = if !client.contain_service(&service_name).await {
+        None
+    } else {
+        let spans = client.find_traces_from_services(&service_name).await;
+        Some(spans)
+    }
+    .unwrap();
+
+    let err_msg = spans[0].tags.iter().find(|f| f.key == "error.message");
+    let err_kind = spans[0].tags.iter().find(|f| f.key == "error.type");
+    let err_stack = spans[0].tags.iter().find(|f| f.key == "error.stack");
+
+    assert_eq!("Error: error message", err_msg.unwrap().v_str);
+    assert_eq!("Error", err_kind.unwrap().v_str);
+    assert_eq!("Stack:\nError: error message", err_stack.unwrap().v_str);
+}
+
+#[derive(Debug)]
+struct Error {
+    message: String,
+}
+
+impl std::error::Error for Error {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("Error: {}", &self.message))
+    }
 }


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-1583

Still need to add some documentation to explain that in order to let the error to show up there's the need to explicitly cast the error to `&dyn std::error::Error`. Waiting for a review before doing that

