### PR TITLE
[PAPAY-1395]: Explicitely shutdown the tracer provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ---
 
+## [0.11.1] - 2024-09-12
+
+### Fixed
+
+- Shutdown the tracing provider before exiting ([bug](https://github.com/open-telemetry/opentelemetry-rust/issues/1961))
+
+---
+
 ## [0.11.0] - 2024-07-24
 
 ### Updated
@@ -231,7 +239,8 @@ jaeger:
 
 
 
-[Unreleased]: https://github.com/primait/prima_tracing.rs/compare/0.11.0...HEAD
+[Unreleased]: https://github.com/primait/prima_tracing.rs/compare/0.11.1...HEAD
+[0.11.1]: https://github.com/primait/prima_tracing.rs/compare/0.11.0...0.11.1
 [0.11.0]: https://github.com/primait/prima_tracing.rs/compare/0.10.0...0.11.0
 [0.10.0]: https://github.com/primait/prima_tracing.rs/compare/0.9.5...0.10.0
 [0.9.4]: https://github.com/primait/prima_tracing.rs/compare/0.9.3...0.9.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ serde_json = "^1.0"
 # dates
 chrono = {version = "^0.4", default-features = false, features = ["serde", "clock"]}
 url = "2.5.0"
+once_cell = "1.19.0"
 
 [dev-dependencies]
 actix-web = "4.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "prima-tracing"
 readme = "README.md"
 repository = "https://github.com/primait/prima_tracing.rs"
-version = "0.11.0"
+version = "0.11.1"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Install from [crates.io](https://crates.io/crates/prima-tracing)
 
 ```toml
-prima-tracing = "0.9"
+prima-tracing = "0.11"
 ```
 
 ### Cargo features

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -84,7 +84,7 @@ pub struct Uninstall;
 impl Drop for Uninstall {
     fn drop(&mut self) {
         #[cfg(feature = "traces")]
-        opentelemetry::global::shutdown_tracer_provider();
+        crate::telemetry::shutdown_tracer_provider();
     }
 }
 /// Information about the current app context like name or environment

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -75,6 +75,7 @@ pub fn configure<T>(config: &SubscriberConfig<T>) -> Tracer {
         .build()
 }
 
+// Consider to remove this wrapper when https://github.com/open-telemetry/opentelemetry-rust/issues/1961 is resolved
 static TRACER_PROVIDER: Lazy<Mutex<Option<trace::TracerProvider>>> = Lazy::new(Default::default);
 
 fn set_tracer_provider(new_provider: trace::TracerProvider) {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,3 +1,4 @@
+use once_cell::sync::Lazy;
 use opentelemetry::global;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry::KeyValue;
@@ -6,6 +7,8 @@ use opentelemetry_sdk::{
     trace::{self, Tracer},
     Resource,
 };
+use std::mem;
+use std::sync::Mutex;
 
 use crate::SubscriberConfig;
 
@@ -64,12 +67,37 @@ pub fn configure<T>(config: &SubscriberConfig<T>) -> Tracer {
         .install_batch(runtime)
         .expect("Failed to configure the OpenTelemetry tracer provider");
 
-    global::set_tracer_provider(tracer_provider.clone());
+    set_tracer_provider(tracer_provider.clone());
 
     tracer_provider
         .tracer_builder("prima-tracing")
         .with_version(env!("CARGO_PKG_VERSION"))
         .build()
+}
+
+static TRACER_PROVIDER: Lazy<Mutex<Option<trace::TracerProvider>>> = Lazy::new(Default::default);
+
+fn set_tracer_provider(new_provider: trace::TracerProvider) {
+    global::set_tracer_provider(new_provider.clone());
+
+    let mut tracer_provider = TRACER_PROVIDER
+        .lock()
+        .expect("OpenTelemetry tracer provider mutex poisoned");
+    _ = mem::replace(&mut *tracer_provider, Some(new_provider));
+}
+
+pub(crate) fn shutdown_tracer_provider() {
+    global::shutdown_tracer_provider();
+
+    let tracer_provider = TRACER_PROVIDER
+        .lock()
+        .expect("OpenTelemetry tracer provider mutex poisoned")
+        .take()
+        .expect("OpenTelemetry tracer provider is missing, cannot shutdown");
+
+    if let Err(err) = tracer_provider.shutdown() {
+        eprintln!("Failed to shutdown the OpenTelemetry tracer provider: {err:?}");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PAPAY-1395

After upgrading this library in our application, we observed the following errors logged after every execution of a scheduled tasks:
```
A Tokio 1.x context was found, but it is being shutdown.
thread '<unnamed>' panicked at .cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/time/entry.rs:568:9:
```

This is related to https://github.com/open-telemetry/opentelemetry-rust/issues/1961.

It appears that we should explicitely shutdown the tracer provider, otherwise it doesn't flush all the data when the application terminates. Additionally, the process remains active and the Tokio' runtime complains.