### PR TITLE
feat(async-graphql): make TracingRootFieldsExtension log levels configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this project adheres to
 
 ---
 
+## [0.22.0] - 2026-04-02
+
+### Changed
+
+- `TracingRootFieldsExtension`: all log events now default to `TRACE` level
+  instead of `ERROR`. This affects parse errors, validation errors, and
+  root-field resolver errors.
+- `TracingRootFieldsExtension` now supports configuring the log level for each
+  event category independently via builder methods:
+  - `.with_parse_error_level(Level)` — log level for query parse failures
+  - `.with_validation_error_level(Level)` — log level for schema validation errors
+  - `.with_resolve_error_level(Level)` — log level for root-field resolver errors
+  - `.with_field_started_level(Level)` — log level when a root-field resolver begins
+  - `.with_field_completed_level(Level)` — log level when a root-field resolver
+    completes successfully
+
+### ⚠️ Breaking Changes
+
+- The default log level for parse errors, validation errors, and resolver errors
+  in `TracingRootFieldsExtension` changed from `ERROR` to `TRACE`. Call
+  `.parse_error_level(Level::ERROR)` etc. on the builder to restore the previous
+  behaviour.
+
+---
+
 ## [0.21.0] - 2026-03-31
 
 ### Added
@@ -421,7 +446,8 @@ jaeger:
     COLLECTOR_OTLP_HTTP_HOST_PORT: 55681
 ```
 
-[Unreleased]: https://github.com/primait/prima_tracing.rs/compare/0.21.0...HEAD
+[Unreleased]: https://github.com/primait/prima_tracing.rs/compare/0.22.0...HEAD
+[0.22.0]: https://github.com/primait/prima_tracing.rs/compare/0.21.0...0.22.0
 [0.21.0]: https://github.com/primait/prima_tracing.rs/compare/0.20.0...0.21.0
 [0.20.0]: https://github.com/primait/prima_tracing.rs/compare/0.19.0...0.20.0
 [0.19.0]: https://github.com/primait/prima_tracing.rs/compare/0.18.0...0.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ and this project adheres to
 
 - The default log level for parse errors, validation errors, and resolver errors
   in `TracingRootFieldsExtension` changed from `ERROR` to `TRACE`. Call
-  `.parse_error_level(Level::ERROR)` etc. on the builder to restore the previous
-  behaviour.
+  `.with_parse_error_level(Level::ERROR)` etc. on the builder to restore the
+  previous behaviour.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ and this project adheres to
   root-field resolver errors.
 - `TracingRootFieldsExtension` now supports configuring the log level for each
   event category independently via builder methods:
-  - `.with_parse_error_level(Level)` — log level for query parse failures
-  - `.with_validation_error_level(Level)` — log level for schema validation errors
-  - `.with_resolve_error_level(Level)` — log level for root-field resolver errors
+  - `.with_parse_level(Level)` — log level for query parse failures
+  - `.with_validation_level(Level)` — log level for schema validation errors
+  - `.with_resolve_level(Level)` — log level for root-field resolver errors
   - `.with_field_started_level(Level)` — log level when a root-field resolver begins
   - `.with_field_completed_level(Level)` — log level when a root-field resolver
     completes successfully
@@ -28,7 +28,7 @@ and this project adheres to
 
 - The default log level for parse errors, validation errors, and resolver errors
   in `TracingRootFieldsExtension` changed from `ERROR` to `TRACE`. Call
-  `.with_parse_error_level(Level::ERROR)` etc. on the builder to restore the
+  `.with_parse_level(Level::ERROR)` etc. on the builder to restore the
   previous behaviour.
 
 ---

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "prima-tracing"
 readme = "README.md"
 repository = "https://github.com/primait/prima_tracing.rs"
-version = "0.21.0"
+version = "0.22.0"
 rust-version = "1.89"
 
 [features]

--- a/src/async_graphql/mod.rs
+++ b/src/async_graphql/mod.rs
@@ -1,34 +1,109 @@
 use std::sync::Arc;
 
+// `tracing::event!` embeds the level into a `static` metadata block and therefore requires a
+// compile-time constant. This local macro dispatches to the appropriate level-specific macro so
+// that we can use a runtime `tracing::Level` value.
+macro_rules! log_at_level {
+    ($level:expr, $($args:tt)*) => {
+        match $level {
+            ::tracing::Level::TRACE => ::tracing::trace!($($args)*),
+            ::tracing::Level::DEBUG => ::tracing::debug!($($args)*),
+            ::tracing::Level::INFO  => ::tracing::info!($($args)*),
+            ::tracing::Level::WARN  => ::tracing::warn!($($args)*),
+            ::tracing::Level::ERROR => ::tracing::error!($($args)*),
+        }
+    };
+}
+
 use async_graphql::extensions::{
     Extension, ExtensionContext, ExtensionFactory, NextParseQuery, NextRequest, NextResolve,
     NextValidation, ResolveInfo,
 };
 use async_graphql::parser::types::ExecutableDocument;
 use async_graphql::{Response, ServerError, ServerResult, ValidationResult, Value, Variables};
-use tracing::{info_span, Instrument};
+use tracing::{info_span, Instrument, Level};
 
 /// A GraphQL extension that traces every executed root-level field via `tracing`.
 ///
 /// For each root-level GraphQL field it emits:
 /// - An `INFO` span named `graphql_root_field` containing the field name,
 ///   the operation type, the parent type, and the return type
-/// - `TRACE` logs for start/completion
-/// - An `ERROR` log if the field resolution returned errors
+/// - Configurable-level logs for field start/completion (default: `TRACE`)
+/// - A configurable-level log if the field resolution returned errors (default: `TRACE`)
 ///
 /// Additionally, it proactively tracks schema contract violations to surface breaking changes:
-/// - An `ERROR` log when the incoming query document fails to parse (syntax error)
-/// - An `ERROR` log per validation error when the query references fields or types that don't
-///   exist in the schema (e.g. unknown fields, wrong argument types, missing required args)
+/// - A configurable-level log when the incoming query document fails to parse (default: `TRACE`)
+/// - A configurable-level log per validation error when the query references fields or types
+///   that don't exist in the schema (e.g. unknown fields, wrong argument types, missing required
+///   args) (default: `TRACE`)
+///
+/// Use the builder methods to override the log level for each category:
+///
+/// ```rust
+/// use prima_tracing::async_graphql::TracingRootFieldsExtension;
+/// use tracing::Level;
+///
+/// TracingRootFieldsExtension::new("my_schema")
+///     .with_parse_error_level(Level::ERROR)
+///     .with_validation_error_level(Level::ERROR)
+///     .with_resolve_error_level(Level::WARN)
+///     .with_field_started_level(Level::DEBUG)
+///     .with_field_completed_level(Level::DEBUG);
+/// ```
 pub struct TracingRootFieldsExtension {
     schema: Arc<str>,
+    /// Log level emitted when a query document fails to parse.
+    parse_error_level: Level,
+    /// Log level emitted per validation error (unknown fields, wrong types, missing args, …).
+    validation_error_level: Level,
+    /// Log level emitted when a root-field resolver returns an error.
+    resolve_error_level: Level,
+    /// Log level emitted when a root-field resolver begins execution.
+    field_started_level: Level,
+    /// Log level emitted when a root-field resolver completes successfully.
+    field_completed_level: Level,
 }
 
 impl TracingRootFieldsExtension {
     pub fn new(schema: impl Into<Arc<str>>) -> Self {
         Self {
             schema: schema.into(),
+            parse_error_level: Level::TRACE,
+            validation_error_level: Level::TRACE,
+            resolve_error_level: Level::TRACE,
+            field_started_level: Level::TRACE,
+            field_completed_level: Level::TRACE,
         }
+    }
+
+    /// Set the log level for query parse errors.
+    pub fn with_parse_error_level(mut self, level: Level) -> Self {
+        self.parse_error_level = level;
+        self
+    }
+
+    /// Set the log level for schema validation errors.
+    pub fn with_validation_error_level(mut self, level: Level) -> Self {
+        self.validation_error_level = level;
+        self
+    }
+
+    /// Set the log level for root-field resolver errors.
+    pub fn with_resolve_error_level(mut self, level: Level) -> Self {
+        self.resolve_error_level = level;
+        self
+    }
+
+    /// Set the log level emitted when a root-field resolver begins execution.
+    pub fn with_field_started_level(mut self, level: Level) -> Self {
+        self.field_started_level = level;
+        self
+    }
+
+    /// Set the log level emitted when a root-field resolver completes successfully.
+    pub fn with_field_completed_level(mut self, level: Level) -> Self {
+        self.field_completed_level = level;
+        self
     }
 }
 
@@ -36,12 +111,22 @@ impl ExtensionFactory for TracingRootFieldsExtension {
     fn create(&self) -> Arc<dyn Extension> {
         Arc::new(TracingRootFieldsExtensionInstance {
             schema: self.schema.clone(),
+            parse_error_level: self.parse_error_level,
+            validation_error_level: self.validation_error_level,
+            resolve_error_level: self.resolve_error_level,
+            field_started_level: self.field_started_level,
+            field_completed_level: self.field_completed_level,
         })
     }
 }
 
 struct TracingRootFieldsExtensionInstance {
     schema: Arc<str>,
+    parse_error_level: Level,
+    validation_error_level: Level,
+    resolve_error_level: Level,
+    field_started_level: Level,
+    field_completed_level: Level,
 }
 
 #[async_trait::async_trait]
@@ -59,7 +144,8 @@ impl Extension for TracingRootFieldsExtensionInstance {
         next: NextParseQuery<'_>,
     ) -> ServerResult<ExecutableDocument> {
         next.run(ctx, query, variables).await.inspect_err(|err| {
-            tracing::error!(
+            log_at_level!(
+                self.parse_error_level,
                 error = %err,
                 "graphql query parse error: request does not match expected schema syntax"
             );
@@ -73,7 +159,8 @@ impl Extension for TracingRootFieldsExtensionInstance {
     ) -> Result<ValidationResult, Vec<ServerError>> {
         next.run(ctx).await.inspect_err(|errors| {
             for err in errors {
-                tracing::error!(
+                log_at_level!(
+                    self.validation_error_level,
                     error = %err.message,
                     locations = ?err.locations,
                     "graphql validation error: request violates schema contract"
@@ -111,11 +198,11 @@ impl Extension for TracingRootFieldsExtensionInstance {
             return_type = %info.return_type
         );
         async move {
-            tracing::trace!("graphql field started");
+            log_at_level!(self.field_started_level, "graphql field started");
             next.run(ctx, info)
                 .await
-                .inspect(|_| tracing::trace!("graphql field completed successfully"))
-                .inspect_err(|err| tracing::error!(error = %err, "graphql root resolver {} resolved with error", root_field_name))
+                .inspect(|_| log_at_level!(self.field_completed_level, "graphql field completed successfully"))
+                .inspect_err(|err| log_at_level!(self.resolve_error_level, error = %err, "graphql root resolver {} resolved with error", root_field_name))
         }
         .instrument(span)
         .await

--- a/src/async_graphql/mod.rs
+++ b/src/async_graphql/mod.rs
@@ -44,20 +44,20 @@ use tracing::{info_span, Instrument, Level};
 /// use tracing::Level;
 ///
 /// TracingRootFieldsExtension::new("my_schema")
-///     .with_parse_error_level(Level::ERROR)
-///     .with_validation_error_level(Level::ERROR)
-///     .with_resolve_error_level(Level::WARN)
+///     .with_parse_level(Level::ERROR)
+///     .with_validation_level(Level::ERROR)
+///     .with_resolve_level(Level::WARN)
 ///     .with_field_started_level(Level::DEBUG)
 ///     .with_field_completed_level(Level::DEBUG);
 /// ```
 pub struct TracingRootFieldsExtension {
     schema: Arc<str>,
     /// Log level emitted when a query document fails to parse.
-    parse_error_level: Level,
+    parse_level: Level,
     /// Log level emitted per validation error (unknown fields, wrong types, missing args, …).
-    validation_error_level: Level,
+    validation_level: Level,
     /// Log level emitted when a root-field resolver returns an error.
-    resolve_error_level: Level,
+    resolve_level: Level,
     /// Log level emitted when a root-field resolver begins execution.
     field_started_level: Level,
     /// Log level emitted when a root-field resolver completes successfully.
@@ -68,29 +68,29 @@ impl TracingRootFieldsExtension {
     pub fn new(schema: impl Into<Arc<str>>) -> Self {
         Self {
             schema: schema.into(),
-            parse_error_level: Level::TRACE,
-            validation_error_level: Level::TRACE,
-            resolve_error_level: Level::TRACE,
+            parse_level: Level::TRACE,
+            validation_level: Level::TRACE,
+            resolve_level: Level::TRACE,
             field_started_level: Level::TRACE,
             field_completed_level: Level::TRACE,
         }
     }
 
     /// Set the log level for query parse errors.
-    pub fn with_parse_error_level(mut self, level: Level) -> Self {
-        self.parse_error_level = level;
+    pub fn with_parse_level(mut self, level: Level) -> Self {
+        self.parse_level = level;
         self
     }
 
     /// Set the log level for schema validation errors.
-    pub fn with_validation_error_level(mut self, level: Level) -> Self {
-        self.validation_error_level = level;
+    pub fn with_validation_level(mut self, level: Level) -> Self {
+        self.validation_level = level;
         self
     }
 
     /// Set the log level for root-field resolver errors.
-    pub fn with_resolve_error_level(mut self, level: Level) -> Self {
-        self.resolve_error_level = level;
+    pub fn with_resolve_level(mut self, level: Level) -> Self {
+        self.resolve_level = level;
         self
     }
 
@@ -111,9 +111,9 @@ impl ExtensionFactory for TracingRootFieldsExtension {
     fn create(&self) -> Arc<dyn Extension> {
         Arc::new(TracingRootFieldsExtensionInstance {
             schema: self.schema.clone(),
-            parse_error_level: self.parse_error_level,
-            validation_error_level: self.validation_error_level,
-            resolve_error_level: self.resolve_error_level,
+            parse_level: self.parse_level,
+            validation_level: self.validation_level,
+            resolve_level: self.resolve_level,
             field_started_level: self.field_started_level,
             field_completed_level: self.field_completed_level,
         })
@@ -122,9 +122,9 @@ impl ExtensionFactory for TracingRootFieldsExtension {
 
 struct TracingRootFieldsExtensionInstance {
     schema: Arc<str>,
-    parse_error_level: Level,
-    validation_error_level: Level,
-    resolve_error_level: Level,
+    parse_level: Level,
+    validation_level: Level,
+    resolve_level: Level,
     field_started_level: Level,
     field_completed_level: Level,
 }
@@ -145,7 +145,7 @@ impl Extension for TracingRootFieldsExtensionInstance {
     ) -> ServerResult<ExecutableDocument> {
         next.run(ctx, query, variables).await.inspect_err(|err| {
             log_at_level!(
-                self.parse_error_level,
+                self.parse_level,
                 error = %err,
                 "graphql query parse error: request does not match expected schema syntax"
             );
@@ -160,7 +160,7 @@ impl Extension for TracingRootFieldsExtensionInstance {
         next.run(ctx).await.inspect_err(|errors| {
             for err in errors {
                 log_at_level!(
-                    self.validation_error_level,
+                    self.validation_level,
                     error = %err.message,
                     locations = ?err.locations,
                     "graphql validation error: request violates schema contract"
@@ -202,7 +202,7 @@ impl Extension for TracingRootFieldsExtensionInstance {
             next.run(ctx, info)
                 .await
                 .inspect(|_| log_at_level!(self.field_completed_level, "graphql field completed successfully"))
-                .inspect_err(|err| log_at_level!(self.resolve_error_level, error = %err, "graphql root resolver {} resolved with error", root_field_name))
+                .inspect_err(|err| log_at_level!(self.resolve_level, error = %err, "graphql root resolver {} resolved with error", root_field_name))
         }
         .instrument(span)
         .await

--- a/tests/async_graphql.rs
+++ b/tests/async_graphql.rs
@@ -148,7 +148,7 @@ mod tests {
             events: Arc::clone(&events),
         };
         let subscriber = tracing_subscriber::registry().with(layer).with(
-            tracing_subscriber::filter::LevelFilter::from_level(Level::DEBUG),
+            tracing_subscriber::filter::LevelFilter::from_level(Level::TRACE),
         );
         (spans, events, subscriber)
     }
@@ -307,7 +307,7 @@ mod tests {
         let captured_events = events.lock().unwrap();
         let error_events: Vec<_> = captured_events
             .iter()
-            .filter(|e| e.level == tracing::Level::ERROR)
+            .filter(|e| e.level == tracing::Level::TRACE)
             .collect();
         assert!(
             !error_events.is_empty(),
@@ -369,7 +369,7 @@ mod tests {
         let captured_events = events.lock().unwrap();
         let error_events: Vec<_> = captured_events
             .iter()
-            .filter(|e| e.level == tracing::Level::ERROR)
+            .filter(|e| e.level == tracing::Level::TRACE)
             .collect();
         assert!(
             !error_events.is_empty(),
@@ -431,7 +431,7 @@ mod tests {
         let captured = events.lock().unwrap();
         let error_events: Vec<_> = captured
             .iter()
-            .filter(|e| e.level == tracing::Level::ERROR)
+            .filter(|e| e.level == tracing::Level::TRACE)
             .collect();
 
         assert!(


### PR DESCRIPTION
## Summary

All log events in `TracingRootFieldsExtension` now default to `TRACE` instead of `ERROR`, and five new builder methods let callers configure the log level per category independently.

## Changes

### `src/async_graphql/mod.rs`
- All five log sites now use a local `log_at_level`
- Five new fields on `TracingRootFieldsExtension` (and its internal instance), all defaulting to `Level::TRACE`:
  - `parse_level` — query parse failures
  - `validation_level` — schema validation errors
  - `resolve_level` — root-field resolver errors
  - `field_started_level` — field execution started
  - `field_completed_level` — field execution completed
- Five corresponding builder methods: `with_parse_level`, `with_validation_level`, `with_resolve_level`, `with_field_started_level`, `with_field_completed_level`

### `tests/async_graphql.rs`
- Subscriber filter changed from `DEBUG` to `TRACE` to capture the new default-level events
- Error-scenario tests updated to assert on `Level::TRACE` events

### `Cargo.toml`
- Version bumped to `0.22.0`

### `CHANGELOG.md`
- Added `0.22.0` entry with Changed and Breaking Changes sections

## ⚠️ Breaking Change

The default log level for parse errors, validation errors, and resolver errors changes from `ERROR` to `TRACE`. To restore previous behaviour:

```rust
TracingRootFieldsExtension::new("my_schema")
    .with_parse_level(Level::ERROR)
    .with_validation_evel(Level::ERROR)
    .with_resolve_level(Level::ERROR);
```